### PR TITLE
docs: add iterable sample

### DIFF
--- a/source/developer-guides/assets/iterable.vala
+++ b/source/developer-guides/assets/iterable.vala
@@ -1,0 +1,90 @@
+using Gee;
+
+public class RangeIterator : Object, Iterator<int>, Traversable<int> {
+
+   public bool read_only {
+       get { return true; }
+   }
+
+   public bool valid {
+       get { return true; }
+   }
+
+   private Range range;
+   private int current;
+
+   public RangeIterator (Range range) {
+       this.range = range;
+       this.current = range.from - 1;
+   }
+
+   public bool next () {
+       if (!has_next ()) {
+           return false;
+       }
+       this.current++;
+       return true;
+   }
+
+   public bool has_next () {
+       return this.current < this.range.to;
+   }
+
+   /* Here the 'new' keyword is used because Object already
+      has a 'get' method. This will hide the original method.
+      Otherwise you'll get a warning. */
+   public new int get () {
+       return this.current;
+   }
+
+   public new RangeIterator dup_data (string key, DuplicateFunc<RangeIterator> f) {
+       return this;
+   }
+
+   public void remove () {
+       assert_not_reached ();
+   }
+
+   public bool @foreach(ForallFunc<int> f) {
+       for (int i = this.range.from; i < this.range.to; i++) {
+           if (! f (i)) {
+               return false;
+           }
+       }
+       return true;
+   }
+}
+
+public class Range : Object, Iterable<int>, Traversable<int> {
+
+   public int from { get; private set; }
+   public int to { get; private set; }
+
+   public Range (int from, int to) {
+       assert (from < to);
+       this.from = from;
+       this.to = to;
+   }
+
+   public Type element_type {
+       get { return typeof (int); }
+   }
+
+   public Iterator<int> iterator () {
+       return new RangeIterator (this);
+   }
+
+   public bool @foreach(ForallFunc<int> f) {
+       for (int i = this.from; i < this.to; i++) {
+           f (i);
+       }
+       return true;
+   }
+}
+
+void main () {
+   foreach (int i in new Range (10, 20)) {
+       stdout.printf ("%d\n", i);
+   }
+}
+

--- a/source/developer-guides/gee-samples/06-custom-iterator.rst
+++ b/source/developer-guides/gee-samples/06-custom-iterator.rst
@@ -1,0 +1,40 @@
+Implementing your own Iterable
+==============================
+
+You will have to implement two interfaces: `Iterable <https://valadoc.org/gee-0.8/Gee.Iterable.html>`_
+with an ``iterator ()`` method and an element_type property as well as an Iterator.
+
+.. literalinclude:: ../assets/iterable.vala
+   :language: vala
+
+Compile and Run
+---------------
+
+.. code-block:: bash
+
+   $ valac --pkg gee-0.8 iterable.vala
+   $ ./iterable
+
+You could even add an each () method for Ruby or Groovy style iteration.
+
+.. code-block:: vala
+
+   public class Range : Object, Iterable<int> {
+
+       // ... (as above)
+
+       public delegate void RangeEachFunc (int i);
+
+       public void each (RangeEachFunc each_func) {
+           foreach (int i in this) {
+               each_func (i);
+           }
+       }
+   }
+
+   void main () {
+       // Pass an anonymous function as parameter
+       new Range (10, 20).each ((i) => {
+           stdout.printf ("%d\n", i);
+       });
+   }


### PR DESCRIPTION
The Iterable / Iterator sample as it exists in https://wiki.gnome.org/Projects/Vala/GeeSamples currently does not compile. Instead we get this

```
18:16:13 ~/Projects/vala-docs/source/developer-guides/assets (docs/add-iterator-sample*) $ valac --pkg gee-0.8 iterable.vala
iterable.vala:37.1-37.42: error: Range: some prerequisites (`Gee.Traversable') are not met
   37 | public class Range : Object, Iterable<int> {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
iterable.vala:3.1-3.50: error: RangeIterator: some prerequisites (`Gee.Traversable') are not met
    3 | public class RangeIterator : Object, Iterator<int> {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
iterable.vala:3.1-3.50: error: `RangeIterator' does not implement interface property `Gee.Iterator.read_only'
    3 | public class RangeIterator : Object, Iterator<int> {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
iterable.vala:3.1-3.50: error: `RangeIterator' does not implement interface property `Gee.Iterator.valid'
    3 | public class RangeIterator : Object, Iterator<int> {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
Compilation failed: 4 error(s), 0 warning(s)
```

The bottom two are easy. Since the last time those demos were visited the interface requires two new properties. I believe because this is not interacting with `remove ()` we can always return `true`.

``` vala
   public bool read_only {
       get { return true; }
   }

   public bool valid {
       get { return true; }
   }
```

The other two I have no idea about. The only search hit for this is https://mail.gnome.org/archives/vala-list/2012-September/msg00114.html from 2012-09-27 and the only responses were in my opinion non answers.

IF we also have to implement `Traversable` like I tried to do so in the current file I get a different error.

```
18:16:23 ~/Projects/vala-docs/source/developer-guides/assets (docs/add-iterator-sample*) $ valac --pkg gee-0.8 iterable.vala
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c: In function ‘range_iterator_gee_traversable_get_g_dup_func’:
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c:363:33: error: expected expression before ‘;’ token
  363 |         return (GBoxedCopyFunc) ;
      |                                 ^
In file included from /usr/include/glib-2.0/glib/gthread.h:34,
                 from /usr/include/glib-2.0/glib/gasyncqueue.h:34,
                 from /usr/include/glib-2.0/glib.h:34,
                 from /usr/include/glib-2.0/gobject/gbinding.h:30,
                 from /usr/include/glib-2.0/glib-object.h:24,
                 from /home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c:4:
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c: In function ‘range_iterator_get_type’:
/usr/include/glib-2.0/glib/gatomic.h:131:5: warning: argument 2 of ‘__atomic_load’ discards ‘volatile’ qualifier [-Wdiscarded-qualifiers]
  131 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
      |     ^~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gthread.h:272:7: note: in expansion of macro ‘g_atomic_pointer_get’
  272 |     (!g_atomic_pointer_get (location) &&                             \
      |       ^~~~~~~~~~~~~~~~~~~~
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c:417:13: note: in expansion of macro ‘g_once_init_enter’
  417 |         if (g_once_init_enter (&range_iterator_type_id__once)) {
      |             ^~~~~~~~~~~~~~~~~
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c: In function ‘range_gee_iterable_get_g_dup_func’:
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c:597:33: error: expected expression before ‘;’ token
  597 |         return (GBoxedCopyFunc) ;
      |                                 ^
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c: In function ‘range_gee_traversable_get_g_dup_func’:
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c:626:33: error: expected expression before ‘;’ token
  626 |         return (GBoxedCopyFunc) ;
      |                                 ^
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c: In function ‘range_get_type’:
/usr/include/glib-2.0/glib/gatomic.h:131:5: warning: argument 2 of ‘__atomic_load’ discards ‘volatile’ qualifier [-Wdiscarded-qualifiers]
  131 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
      |     ^~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gthread.h:272:7: note: in expansion of macro ‘g_atomic_pointer_get’
  272 |     (!g_atomic_pointer_get (location) &&                             \
      |       ^~~~~~~~~~~~~~~~~~~~
/home/jgarcia/Projects/vala-docs/source/developer-guides/assets/iterable.vala.c:680:13: note: in expansion of macro ‘g_once_init_enter’
  680 |         if (g_once_init_enter (&range_type_id__once)) {
      |             ^~~~~~~~~~~~~~~~~
error: cc exited with status 256
Compilation failed: 1 error(s), 0 warning(s)
```

The C output for this is completely missing the thing to return. At first I thought this was asking for a https://valadoc.org/gobject-2.0/GLib.Object.dup_data.html but that did not do anything either.

```
static GBoxedCopyFunc
range_iterator_gee_traversable_get_g_dup_func (RangeIterator* self)
{
	return (GBoxedCopyFunc) ;
}
```

I also tried going with one of the abstract implementations but those also raise the first error mentioned here. May come back to this later. At the moment I am not sure where to get more information to try and figure this out short of asking at https://gitlab.gnome.org/GNOME/libgee or digging through the compiler.