### PR TITLE
feat: add numeric suffix info

### DIFF
--- a/docs/developer-guides/documentation/vala-for-csharp-devs/06-value-types.md
+++ b/docs/developer-guides/documentation/vala-for-csharp-devs/06-value-types.md
@@ -9,3 +9,34 @@
 -   no `decimal`
 -   C# `char` is UCS-2, not Vala's `char`, but similar to Vala\'s UCS-4
     `unichar`
+
+## Numeric Suffixes
+
+Both Vala and C# support numeric suffixes and are case-insensitive. The following suffixes are supported in Vala:
+
+**Integer Suffixes**
+
+| Suffix | Type   |
+|--------|--------|
+|        | int    |
+| u      | uint   |
+| l      | long   |
+| ll     | int64  |
+| ul     | ulong  |
+| ull    | uint64 |
+
+**Floating-point Suffixes**
+
+| Suffix | Type   |
+|--------|--------|
+|        | double |
+| f      | float  |
+| d      | double |
+
+Differences between Vala and C#:
+- Vala does not support the `m` suffix, which represents the decimal type
+- Vala does not support rearranging the order of the suffix `ul` to be `lu`
+- Vala does not infer the type of `l` to be either `long` or `ulong`
+- Vala does not infer the type of `u` to be either `uint` or `ulong`
+- Vala does not infer the type of suffixless numbers.
+- C# does not have the `ull` or `ll` suffixes.

--- a/docs/tutorials/programming-language/main/02-00-basics.md
+++ b/docs/tutorials/programming-language/main/02-00-basics.md
@@ -12,6 +12,7 @@
 - [2.4.5. Static Type Casting](02-00-basics/02-04-data-types#_2-4-5-static-type-casting)
 - [2.4.6. Type Inference](02-00-basics/02-04-data-types#_2-4-6-type-inference)
 - [2.4.7. Defining new Type from other](02-00-basics/02-04-data-types#_2-4-7-defining-new-type-from-other)
+- [2.4.8. Numeric Type Suffixes](02-00-basics/02-04-data-types#_2-4-8-numeric-type-suffixes)
 
 #### [2.5. Operators](02-00-basics/02-05-operators)
 #### [2.6. Control Structures](02-00-basics/02-06-control-structures)

--- a/docs/tutorials/programming-language/main/02-00-basics/02-04-data-types.md
+++ b/docs/tutorials/programming-language/main/02-00-basics/02-04-data-types.md
@@ -354,3 +354,45 @@ public class ValueList : GLib.List<GLib.Value> {
     public static GLib.Type get_type ();
 }
 ```
+
+## 2.4.8. Numeric Type Suffixes
+
+Like many other languages, Vala supports numeric type suffixes. 
+
+The following sections list the supported suffixes, which are case-insensitive:
+
+### 2.4.8.1. Integer Suffixes
+
+| Suffix | Type   |
+|--------|--------|
+|        | int    |
+| u      | uint   |
+| l      | long   |
+| ll     | int64  |
+| ul     | ulong  |
+| ull    | uint64 |
+
+Here are some examples:
+```vala
+var a = 123; // int
+var b = 123u; // uint
+var c = 123l; // long
+var d = 123ll; // ulong
+var e = 123ul; // ulong
+var f = 123ull; // uint64
+```
+
+### 2.4.8.2. Floating-point Suffixes
+
+| Suffix | Type   |
+|--------|--------|
+|        | double |
+| f      | float  |
+| d      | double |
+
+Here are some examples:
+```vala
+var a = 123.0; // double
+var b = 123.0f; // float
+var c = 123.0d; // double
+```


### PR DESCRIPTION
Closes #83 

## Description

The following adds numeric suffix info to `vala for csharp devs` under value types  and the `main` tutorial under data types. 

### Resources
- https://gitlab.gnome.org/GNOME/vala/-/blob/main/vala/valaintegerliteral.vala?ref_type=heads
- https://gitlab.gnome.org/GNOME/vala/-/blob/main/vala/valarealliteral.vala?ref_type=heads
- https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types
- https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types