### PR TITLE
Fix typo 'report' -> 'refer'

### DIFF
--- a/docs/tutorials/programming-language/main/02-00-basics/02-04-data-types.md
+++ b/docs/tutorials/programming-language/main/02-00-basics/02-04-data-types.md
@@ -150,7 +150,7 @@ string contains another, e.g.
 if ("ere" in "Able was I ere I saw Elba.") //...
 ```
 
-For more information, please report to 
+For more information, please refer to 
 [the complete overview of the string class](http://www.valadoc.org/glib-2.0/string.html).
 
 A [sample program](../../../../developer-guides/string-sample) demonstrating string usage is also available.


### PR DESCRIPTION
While reading the docs I thought I saw a typo, there was this:
<img width="666" height="46" alt="image" src="https://github.com/user-attachments/assets/91fd0313-d5ce-46af-a4a5-64100b6ff8cd" />
I changed this "report to" to "refer to".
I hope this isn't 'too small' of a PR to be accepted since it's a really minor change