### PR TITLE
Update references from legacy gee-1.0 to gee-0.8

### DIFF
--- a/docs/developer-guides/documentation/vala-for-csharp-devs/33-collections.md
+++ b/docs/developer-guides/documentation/vala-for-csharp-devs/33-collections.md
@@ -2,7 +2,7 @@
 
 C#: `System.Collections.Generic` namespace
 
-Vala: `Gee` namespace, `--pkg gee-1.0`,
+Vala: `Gee` namespace, `--pkg gee-0.8`,
 [Libgee](https://wiki.gnome.org/Projects/Libgee)
 
 Rough equivalents:

--- a/docs/tutorials/programming-language/main/06-00-libraries.md
+++ b/docs/tutorials/programming-language/main/06-00-libraries.md
@@ -8,13 +8,13 @@ level of Vala specific information.
 A "Vala library" is therefore, the system part:
 
 -   A system library (e.g. *libgee.so*)
--   A *pkg-config* entry (e.g. *gee-1.0.pc*)
+-   A *pkg-config* entry (e.g. *gee-0.8.pc*)
 
 Both of which are installed in the standard locations. And the Vala
 specific files:
 
--   A VAPI file (e.g. *gee-1.0.vapi*)
--   An optional dependency file (e.g. *gee-1.0.deps*)
+-   A VAPI file (e.g. *gee-0.8.vapi*)
+-   An optional dependency file (e.g. *gee-0.8.deps*)
 
 These files are explained later in this section. It should be noted that
 the library names are the same in the Vala specific files as in the

--- a/docs/tutorials/programming-language/main/06-00-libraries/06-01-using-libraries.md
+++ b/docs/tutorials/programming-language/main/06-00-libraries/06-01-using-libraries.md
@@ -6,12 +6,12 @@ package. You tell the compiler that a package is needed by your program
 as follows:
 
 ```shell
-valac --pkg gee-1.0 test.vala
+valac --pkg gee-0.8 test.vala
 ```
 
 This command means your program can use any of the definitions in the
-*gee-1.0.vapi* file, and also any in any of the packages that *gee-1.0*
-depends on. These dependencies would be listed in *gee-1.0.deps* if
+*gee-0.8.vapi* file, and also any in any of the packages that *gee-0.8*
+depends on. These dependencies would be listed in *gee-0.8.deps* if
 there were any. In this example *valac* is set to build all the way to
 binary, and will therefore incorporate information from *pkg-config* to
 link the correct libraries. This is why the *pkg-config* names are also

--- a/docs/tutorials/programming-language/main/06-00-libraries/06-06-using-autotools.md
+++ b/docs/tutorials/programming-language/main/06-00-libraries/06-06-using-autotools.md
@@ -60,7 +60,7 @@ VALAFLAGS = \
     $(top_srcdir)/vapi/config.vapi \
     --vapidir=$(top_srcdir)/vapi \
     --pkg libxml-2.0 \
-    --pkg gee-1.0 \
+    --pkg gee-0.8 \
     --pkg gobject-2.0 \
     --pkg gio-2.0 \
     $(NULL)

--- a/docs/tutorials/programming-language/main/07-00-tools/07-01-valac.md
+++ b/docs/tutorials/programming-language/main/07-00-tools/07-01-valac.md
@@ -39,12 +39,12 @@ valac can also automate the entire build and link project in simple
 cases:
 
 ```shell
-valac -o appname --pkg gee-1.0 file_name_1.vala file_name_2.vala
+valac -o appname --pkg gee-0.8 file_name_1.vala file_name_2.vala
 ```
 
 The `-o` switch requests that an object file is created, rather than
 just outputting C source files. The `--pkg` option says that this build
-needs information from the *gee-1.0* package. You do not need to specify
+needs information from the *gee-0.8* package. You do not need to specify
 details about what libraries to link in, the package has this
 information internally. Finally, a list of source files is given. If you
 need a more complicated build process, use the `-C` switch to generate C


### PR DESCRIPTION
Closes #117 

This PR updates all references of `gee-1.0`, which is an alias for version `0.1` to `0.6` to the latest version, `0.8`.

Almost everywhere, the package `gee-1.0` is not available, unlike `gee-0.8` from what I've found. This might cause some frustration since the versioning isn't linear.