### PR TITLE
fix: All Table of content links now use standard `<ul>` and `<li>` tags

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,53 @@
+/**
+ * Section navigation lists — typography aligned with default VitePress h4
+ * (see issue #130: outline uses ul/li instead of skipped heading levels).
+ */
+.vp-doc .section-toc {
+    list-style: none;
+    padding-left: 0;
+    margin: 1rem 0;
+}
+
+.vp-doc .section-toc > li {
+    margin: 0.5rem 0;
+}
+
+.vp-doc .section-toc a {
+    font-weight: 600;
+    /* Default theme h4-sized body text in doc content */
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    color: var(--vp-c-text-1);
+    text-decoration: none;
+}
+
+.vp-doc .section-toc a:hover {
+    color: var(--vp-c-brand-1);
+}
+
+.vp-doc .section-toc .section-toc-num {
+    margin-right: 0.25rem;
+    color: var(--vp-c-text-2);
+    font-weight: 600;
+    font-size: 0.9375rem;
+}
+
+/* Child links (in-page anchors, extra resources) under one section-toc entry */
+.vp-doc .section-toc .section-toc-sub {
+    list-style: none;
+    padding-left: 1.25rem;
+    margin: 0.35rem 0 0;
+}
+
+.vp-doc .section-toc .section-toc-sub > li {
+    margin: 0.25rem 0;
+}
+
+.vp-doc .section-toc .section-toc-sub a {
+    font-weight: 500;
+    color: var(--vp-c-text-2);
+}
+
+.vp-doc .section-toc .section-toc-sub a:hover {
+    color: var(--vp-c-brand-1);
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,0 +1,6 @@
+import DefaultTheme from 'vitepress/theme'
+import './custom.css'
+
+export default {
+    extends: DefaultTheme,
+}

--- a/docs/contributor-guide/compiler-guide.md
+++ b/docs/contributor-guide/compiler-guide.md
@@ -57,12 +57,14 @@ Luca Bruno <[lethalman88@gmail.com](mailto:lethalman88@gmail.com)>
 
 ## Chapters
 
-#### [1. Project Information](compiler-guide/01-00-project-information)
-#### [2. Environment Setup](compiler-guide/02-00-environment-setup)
-#### [3. The Vala Compiler](compiler-guide/03-00-the-vala-compiler)
-#### [4. Vala Bindings - VAPI](compiler-guide/04-00-vala-bindings-vapi)
-#### [5. libgee Internal](compiler-guide/05-00-internal-libgee)
-#### [6. Other Tools](compiler-guide/06-00-other-tools)
-#### [7. Testing](compiler-guide/07-00-testing)
-#### [8. Documentation](compiler-guide/08-00-documentation)
-#### [9. Build System](compiler-guide/09-00-build-system)
+<ul class="section-toc">
+<li><a href="compiler-guide/01-00-project-information">1. Project Information</a></li>
+<li><a href="compiler-guide/02-00-environment-setup">2. Environment Setup</a></li>
+<li><a href="compiler-guide/03-00-the-vala-compiler">3. The Vala Compiler</a></li>
+<li><a href="compiler-guide/04-00-vala-bindings-vapi">4. Vala Bindings - VAPI</a></li>
+<li><a href="compiler-guide/05-00-internal-libgee">5. libgee Internal</a></li>
+<li><a href="compiler-guide/06-00-other-tools">6. Other Tools</a></li>
+<li><a href="compiler-guide/07-00-testing">7. Testing</a></li>
+<li><a href="compiler-guide/08-00-documentation">8. Documentation</a></li>
+<li><a href="compiler-guide/09-00-build-system">9. Build System</a></li>
+</ul>

--- a/docs/contributor-guide/compiler-guide/03-00-the-vala-compiler.md
+++ b/docs/contributor-guide/compiler-guide/03-00-the-vala-compiler.md
@@ -3,10 +3,12 @@
 I suppose the best place to start is valac, the tool which Vala
 programmers know the best.
 
-#### [3.1. Vala in a Nutshell](03-00-the-vala-compiler/03-01-vala-in-a-nutshell)
-#### [3.2. Parser](03-00-the-vala-compiler/03-02-parser)
-#### [3.3. Semantic Analyzer](03-00-the-vala-compiler/03-03-semantic-analyzer)
-#### [3.4. Symbol Resolution](03-00-the-vala-compiler/03-04-symbol-resolution)
-#### [3.5. Flow Analyzer](03-00-the-vala-compiler/03-05-flow-analyzer)
-#### [3.6. C Code Generation](03-00-the-vala-compiler/03-06-c-code-generation)
-#### [3.7. C Code Compilation and Linking](03-00-the-vala-compiler/03-07-c-code-compilation-and-linking)
+<ul class="section-toc">
+<li><a href="03-00-the-vala-compiler/03-01-vala-in-a-nutshell">3.1. Vala in a Nutshell</a></li>
+<li><a href="03-00-the-vala-compiler/03-02-parser">3.2. Parser</a></li>
+<li><a href="03-00-the-vala-compiler/03-03-semantic-analyzer">3.3. Semantic Analyzer</a></li>
+<li><a href="03-00-the-vala-compiler/03-04-symbol-resolution">3.4. Symbol Resolution</a></li>
+<li><a href="03-00-the-vala-compiler/03-05-flow-analyzer">3.5. Flow Analyzer</a></li>
+<li><a href="03-00-the-vala-compiler/03-06-c-code-generation">3.6. C Code Generation</a></li>
+<li><a href="03-00-the-vala-compiler/03-07-c-code-compilation-and-linking">3.7. C Code Compilation and Linking</a></li>
+</ul>

--- a/docs/contributor-guide/index.md
+++ b/docs/contributor-guide/index.md
@@ -1,6 +1,8 @@
 # Documentation for Contributors to Vala
 
-#### [Compiler Guide](compiler-guide)
+<ul class="section-toc">
+<li><a href="compiler-guide">Compiler Guide</a></li>
+</ul>
 
 Vala follows a collaborative, open source development model. The
 following guidelines are here to help if you want to contribute back to

--- a/docs/developer-guides/bindings.md
+++ b/docs/developer-guides/bindings.md
@@ -1,5 +1,7 @@
 # Bindings
 
-#### [Generating a VAPI with GObject Introspection](bindings/generating-a-vapi-with-gobject-introspection)
-#### [Why Distribute Bindings Upstream](bindings/upstream-guide)
-#### [Writing a VAPI Manually](bindings/writing-a-vapi-manually)
+<ul class="section-toc">
+<li><a href="bindings/generating-a-vapi-with-gobject-introspection">Generating a VAPI with GObject Introspection</a></li>
+<li><a href="bindings/upstream-guide">Why Distribute Bindings Upstream</a></li>
+<li><a href="bindings/writing-a-vapi-manually">Writing a VAPI Manually</a></li>
+</ul>

--- a/docs/developer-guides/bindings/writing-a-vapi-manually.md
+++ b/docs/developer-guides/bindings/writing-a-vapi-manually.md
@@ -47,13 +47,15 @@ style of C. A C binding, however, is only made up of structs and
 functions, so understanding that in enough detail is the purpose of the
 approach.
 
-#### [1. Prerequisites](writing-a-vapi-manually/01-00-prerequisites){style="color: white;"}
-#### [2. Getting Started](writing-a-vapi-manually/02-00-getting-started){style="color: white;"}
-#### [3. Using Vala's Automatic Memory Management](writing-a-vapi-manually/03-00-using-auto-memory-management){style="color: white;"}
-#### [4. Recognizing Vala Semantics in C Code](writing-a-vapi-manually/04-00-recognizing-vala-semantics-in-c-code){style="color: white;"}
-#### [5. Fundamentals of Binding a C Function](writing-a-vapi-manually/05-00-fundamentals-of-binding-a-c-function){style="color: white;"}
-#### [6. Adding Vala Friendly Semantics](writing-a-vapi-manually/06-00-adding-vala-friendly-semantics){style="color: white;"}
-#### [7. Binding a C Function's Parameter and Return Types](writing-a-vapi-manually/07-00-binding-a-c-function-s-parameter-and-return-types){style="color: white;"}
-#### [8. Binding a C Struct's Fields](writing-a-vapi-manually/08-00-binding-a-c-struct-s-fields){style="color: white;"}
-#### [9. Extra Hints](writing-a-vapi-manually/09-00-extra-hints){style="color: white;"}
-#### [10. Awkward Situations](writing-a-vapi-manually/10-00-awkward-situations){style="color: white;"}
+<ul class="section-toc">
+<li><a href="writing-a-vapi-manually/01-00-prerequisites" style="color: white;">1. Prerequisites</a></li>
+<li><a href="writing-a-vapi-manually/02-00-getting-started" style="color: white;">2. Getting Started</a></li>
+<li><a href="writing-a-vapi-manually/03-00-using-auto-memory-management" style="color: white;">3. Using Vala's Automatic Memory Management</a></li>
+<li><a href="writing-a-vapi-manually/04-00-recognizing-vala-semantics-in-c-code" style="color: white;">4. Recognizing Vala Semantics in C Code</a></li>
+<li><a href="writing-a-vapi-manually/05-00-fundamentals-of-binding-a-c-function" style="color: white;">5. Fundamentals of Binding a C Function</a></li>
+<li><a href="writing-a-vapi-manually/06-00-adding-vala-friendly-semantics" style="color: white;">6. Adding Vala Friendly Semantics</a></li>
+<li><a href="writing-a-vapi-manually/07-00-binding-a-c-function-s-parameter-and-return-types" style="color: white;">7. Binding a C Function's Parameter and Return Types</a></li>
+<li><a href="writing-a-vapi-manually/08-00-binding-a-c-struct-s-fields" style="color: white;">8. Binding a C Struct's Fields</a></li>
+<li><a href="writing-a-vapi-manually/09-00-extra-hints" style="color: white;">9. Extra Hints</a></li>
+<li><a href="writing-a-vapi-manually/10-00-awkward-situations" style="color: white;">10. Awkward Situations</a></li>
+</ul>

--- a/docs/developer-guides/bindings/writing-a-vapi-manually/02-00-getting-started.md
+++ b/docs/developer-guides/bindings/writing-a-vapi-manually/02-00-getting-started.md
@@ -1,11 +1,13 @@
 # 2. Getting Started
 
-#### [2.1. The VAPI File](02-00-getting-started/02-01-the-vapi-file)
-#### [2.2. Attribution and License](02-00-getting-started/02-02-attribution-and-license)
-#### [2.3. The CCode Attribute](02-00-getting-started/02-03-the-ccode-attribute)
-#### [2.4. Create a Root Namespace](02-00-getting-started/02-04-create-a-root-namespace)
-#### [2.5. Include the C Header Files](02-00-getting-started/02-05-include-the-c-header-files)
-#### [2.6. Symbol Name Translations](02-00-getting-started/02-06-symbol-name-translations)
-#### [2.7. Code Formatting Conventions](02-00-getting-started/02-07-code-formatting-conventions)
-#### [2.8. Documentation and Valadoc.org](02-00-getting-started/02-08-documentation-and-valadoc-org)
-#### [2.9. The Version Attribute](02-00-getting-started/02-09-the-version-attribute)
+<ul class="section-toc">
+<li><a href="02-00-getting-started/02-01-the-vapi-file">2.1. The VAPI File</a></li>
+<li><a href="02-00-getting-started/02-02-attribution-and-license">2.2. Attribution and License</a></li>
+<li><a href="02-00-getting-started/02-03-the-ccode-attribute">2.3. The CCode Attribute</a></li>
+<li><a href="02-00-getting-started/02-04-create-a-root-namespace">2.4. Create a Root Namespace</a></li>
+<li><a href="02-00-getting-started/02-05-include-the-c-header-files">2.5. Include the C Header Files</a></li>
+<li><a href="02-00-getting-started/02-06-symbol-name-translations">2.6. Symbol Name Translations</a></li>
+<li><a href="02-00-getting-started/02-07-code-formatting-conventions">2.7. Code Formatting Conventions</a></li>
+<li><a href="02-00-getting-started/02-08-documentation-and-valadoc-org">2.8. Documentation and Valadoc.org</a></li>
+<li><a href="02-00-getting-started/02-09-the-version-attribute">2.9. The Version Attribute</a></li>
+</ul>

--- a/docs/developer-guides/bindings/writing-a-vapi-manually/03-00-using-auto-memory-management.md
+++ b/docs/developer-guides/bindings/writing-a-vapi-manually/03-00-using-auto-memory-management.md
@@ -25,7 +25,9 @@ There are 4 memory management schemes in Vala:
 | Singly-Owned      | Heap allocator     | Yes          | Expensive     |
 | Reference-Counted | Heap allocator     | Yes          | Cheap         |
 
-#### [3.1. Pointers in C (or what all these *'s mean)](03-00-using-auto-memory-management/03-01-pointers-in-c)
-#### [3.2. Constants, the Stack and the Heap in C](03-00-using-auto-memory-management/03-02-constants-the-stack-and-the-heap-in-c)
-#### [3.3. The Concept of "Ownership" in Vala](03-00-using-auto-memory-management/03-03-the-concept-of-ownership-in-vala)
-#### [3.4. Binding to C Heap Handlers](03-00-using-auto-memory-management/03-04-binding-to-c-heap-handnlers)
+<ul class="section-toc">
+<li><a href="03-00-using-auto-memory-management/03-01-pointers-in-c">3.1. Pointers in C (or what all these *'s mean)</a></li>
+<li><a href="03-00-using-auto-memory-management/03-02-constants-the-stack-and-the-heap-in-c">3.2. Constants, the Stack and the Heap in C</a></li>
+<li><a href="03-00-using-auto-memory-management/03-03-the-concept-of-ownership-in-vala">3.3. The Concept of &quot;Ownership&quot; in Vala</a></li>
+<li><a href="03-00-using-auto-memory-management/03-04-binding-to-c-heap-handnlers">3.4. Binding to C Heap Handlers</a></li>
+</ul>

--- a/docs/developer-guides/bindings/writing-a-vapi-manually/04-00-recognizing-vala-semantics-in-c-code.md
+++ b/docs/developer-guides/bindings/writing-a-vapi-manually/04-00-recognizing-vala-semantics-in-c-code.md
@@ -14,13 +14,30 @@ determining all the important types to be bound. For each one, find any
 allocation functions, copy functions and cleanup functions. From these,
 the right binding strategy can be inferred.
 
-#### [4.1. Constants](04-00-recognizing-vala-semantics-in-c-code/04-01-constants)
-#### [4.2. Enums and Flags](04-00-recognizing-vala-semantics-in-c-code/04-02-enums-and-flags)
-#### [4.3. Simple Type Structs](04-00-recognizing-vala-semantics-in-c-code/04-03-simple-type-structs)
-#### [4.4. Structs](04-00-recognizing-vala-semantics-in-c-code/04-04-structs)
-#### [4.5. Compact Classes](04-00-recognizing-vala-semantics-in-c-code/04-05-compact-classes)
-- [4.5.1. Singly-Owned Classes](04-00-recognizing-vala-semantics-in-c-code/04-05-compact-classes#_4-5-1-singly-owned-classes)
-- [4.5.2. Reference-Counted Classes](04-00-recognizing-vala-semantics-in-c-code/04-05-compact-classes#_4-5-2-reference-counted-classes)
-
-#### [4.6. Functions](04-00-recognizing-vala-semantics-in-c-code/04-06-functions)
-#### [4.7. Delegates](04-00-recognizing-vala-semantics-in-c-code/04-07-delegates)
+<ul class="section-toc">
+  <li>
+    <a href="04-00-recognizing-vala-semantics-in-c-code/04-01-constants">4.1. Constants</a>
+  </li>
+  <li>
+    <a href="04-00-recognizing-vala-semantics-in-c-code/04-02-enums-and-flags">4.2. Enums and Flags</a>
+  </li>
+  <li>
+    <a href="04-00-recognizing-vala-semantics-in-c-code/04-03-simple-type-structs">4.3. Simple Type Structs</a>
+  </li>
+  <li>
+    <a href="04-00-recognizing-vala-semantics-in-c-code/04-04-structs">4.4. Structs</a>
+  </li>
+  <li>
+    <a href="04-00-recognizing-vala-semantics-in-c-code/04-05-compact-classes">4.5. Compact Classes</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="04-00-recognizing-vala-semantics-in-c-code/04-05-compact-classes#_4-5-1-singly-owned-classes">4.5.1. Singly-Owned Classes</a></li>
+      <li><a href="04-00-recognizing-vala-semantics-in-c-code/04-05-compact-classes#_4-5-2-reference-counted-classes">4.5.2. Reference-Counted Classes</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="04-00-recognizing-vala-semantics-in-c-code/04-06-functions">4.6. Functions</a>
+  </li>
+  <li>
+    <a href="04-00-recognizing-vala-semantics-in-c-code/04-07-delegates">4.7. Delegates</a>
+  </li>
+</ul>

--- a/docs/developer-guides/bindings/writing-a-vapi-manually/05-00-fundamentals-of-binding-a-c-function.md
+++ b/docs/developer-guides/bindings/writing-a-vapi-manually/05-00-fundamentals-of-binding-a-c-function.md
@@ -3,14 +3,16 @@
 A function signature comprises the parameters of the function and any
 return value.
 
-#### [5.1. Out and Reference Parameters and Return Values](05-00-fundamentals-of-binding-a-c-function/05-01-out-and-reference-parameters-and-return-values)
-#### [5.2. Ownership](05-00-fundamentals-of-binding-a-c-function/05-02-ownership)
-#### [5.3. Nullability](05-00-fundamentals-of-binding-a-c-function/05-03-nullability)
-#### [5.4. Static Methods](05-00-fundamentals-of-binding-a-c-function/05-04-static-methods)
-#### [5.5. Changing the Position of Generated Arguments](05-00-fundamentals-of-binding-a-c-function/05-05-changing-the-position-of-generated-arguments)
-#### [5.6. Default Values and Changing an Argument's Position](05-00-fundamentals-of-binding-a-c-function/05-06-default-values-and-changing-an-argument-s-position)
-#### [5.7. Adapting a Signature with a Vala Wrapper](05-00-fundamentals-of-binding-a-c-function/05-07-adapting-a-signature-with-a-vala-wrapper)
-#### [5.8. Variadic Arguments (a.k.a. "...")](05-00-fundamentals-of-binding-a-c-function/05-08-variadic-arguments)
-#### [5.9. Functions that Do Not Return](05-00-fundamentals-of-binding-a-c-function/05-09-functions-that-do-not-return)
-#### [5.10. Methods that Change the Instance Reference](05-00-fundamentals-of-binding-a-c-function/05-10-methods-that-change-the-instance-reference)
-#### [5.11. Methods that Destroy the Instance Reference](05-00-fundamentals-of-binding-a-c-function/05-11-methods-that-destroy-the-instance-reference)
+<ul class="section-toc">
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-01-out-and-reference-parameters-and-return-values">5.1. Out and Reference Parameters and Return Values</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-02-ownership">5.2. Ownership</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-03-nullability">5.3. Nullability</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-04-static-methods">5.4. Static Methods</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-05-changing-the-position-of-generated-arguments">5.5. Changing the Position of Generated Arguments</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-06-default-values-and-changing-an-argument-s-position">5.6. Default Values and Changing an Argument's Position</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-07-adapting-a-signature-with-a-vala-wrapper">5.7. Adapting a Signature with a Vala Wrapper</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-08-variadic-arguments">5.8. Variadic Arguments (a.k.a. &quot;...&quot;)</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-09-functions-that-do-not-return">5.9. Functions that Do Not Return</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-10-methods-that-change-the-instance-reference">5.10. Methods that Change the Instance Reference</a></li>
+<li><a href="05-00-fundamentals-of-binding-a-c-function/05-11-methods-that-destroy-the-instance-reference">5.11. Methods that Destroy the Instance Reference</a></li>
+</ul>

--- a/docs/developer-guides/bindings/writing-a-vapi-manually/06-00-adding-vala-friendly-semantics.md
+++ b/docs/developer-guides/bindings/writing-a-vapi-manually/06-00-adding-vala-friendly-semantics.md
@@ -9,6 +9,8 @@ Vala has some special method names that allow the method to be used with
 Vala syntax. Differences between C and Vala can be captured using the
 `CCode` attribute.
 
-#### [6.1. to_string () Methods](06-00-adding-vala-friendly-semantics/06-01-to-string-methods)
-#### [6.2. Properties](06-00-adding-vala-friendly-semantics/06-02-properties)
-#### [6.3. Collections](06-00-adding-vala-friendly-semantics/06-03-collections)
+<ul class="section-toc">
+<li><a href="06-00-adding-vala-friendly-semantics/06-01-to-string-methods">6.1. to_string () Methods</a></li>
+<li><a href="06-00-adding-vala-friendly-semantics/06-02-properties">6.2. Properties</a></li>
+<li><a href="06-00-adding-vala-friendly-semantics/06-03-collections">6.3. Collections</a></li>
+</ul>

--- a/docs/developer-guides/bindings/writing-a-vapi-manually/07-00-binding-a-c-function-s-parameter-and-return-types.md
+++ b/docs/developer-guides/bindings/writing-a-vapi-manually/07-00-binding-a-c-function-s-parameter-and-return-types.md
@@ -1,19 +1,37 @@
 # 7. Binding a C Function's Parameter and Return Types
 
-#### [7.1. Basic Types](07-00-binding-a-c-function-s-parameter-and-return-types/07-01-basic-types)
-#### [7.2. Structs](07-00-binding-a-c-function-s-parameter-and-return-types/07-02-structs)
-#### [7.3. Arrays](07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays)
-- [7.3.1. Array Length is Passed as an Argument](07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-1-array-length-is-passed-as-an-argument)
-- [7.3.2. Array is Null-Terminated](07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-2-array-is-null-terminated)
-- [7.3.3. Array Length is a Constant Expression](07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-3-array-length-is-a-constant-expression)
-- [7.3.4. Array Length is Unknown](07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-4-array-length-is-unknown)
-- [7.3.5. Array Length is Known by Some Awkward Means](07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-5-array-length-is-known-by-some-awkward-means)
-
-#### [7.4. Strings and Buffers](07-00-binding-a-c-function-s-parameter-and-return-types/07-04-strings-and-buffers)
-#### [7.5. Function Pointers](07-00-binding-a-c-function-s-parameter-and-return-types/07-05-function-pointers)
-#### [7.6. Parameters of Variable Type (Generics)](07-00-binding-a-c-function-s-parameter-and-return-types/07-06-parameters-of-variable-type-generics)
-- [7.6.1. Generic Methods](07-00-binding-a-c-function-s-parameter-and-return-types/07-06-parameters-of-variable-type-generics#_7-6-1-generic-methods)
-- [7.6.2. Generic Classes and Structs](07-00-binding-a-c-function-s-parameter-and-return-types/07-06-parameters-of-variable-type-generics#_7-6-2-generic-classes-and-structs)
-- [7.6.3. The User Pointer Case](07-00-binding-a-c-function-s-parameter-and-return-types/07-06-parameters-of-variable-type-generics#_7-6-3-the-user-pointer-case)
-
-#### [7.7. Pointers](07-00-binding-a-c-function-s-parameter-and-return-types/07-07-pointers)
+<ul class="section-toc">
+  <li>
+    <a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-01-basic-types">7.1. Basic Types</a>
+  </li>
+  <li>
+    <a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-02-structs">7.2. Structs</a>
+  </li>
+  <li>
+    <a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays">7.3. Arrays</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-1-array-length-is-passed-as-an-argument">7.3.1. Array Length is Passed as an Argument</a></li>
+      <li><a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-2-array-is-null-terminated">7.3.2. Array is Null-Terminated</a></li>
+      <li><a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-3-array-length-is-a-constant-expression">7.3.3. Array Length is a Constant Expression</a></li>
+      <li><a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-4-array-length-is-unknown">7.3.4. Array Length is Unknown</a></li>
+      <li><a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-03-arrays#_7-3-5-array-length-is-known-by-some-awkward-means">7.3.5. Array Length is Known by Some Awkward Means</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-04-strings-and-buffers">7.4. Strings and Buffers</a>
+  </li>
+  <li>
+    <a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-05-function-pointers">7.5. Function Pointers</a>
+  </li>
+  <li>
+    <a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-06-parameters-of-variable-type-generics">7.6. Parameters of Variable Type (Generics)</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-06-parameters-of-variable-type-generics#_7-6-1-generic-methods">7.6.1. Generic Methods</a></li>
+      <li><a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-06-parameters-of-variable-type-generics#_7-6-2-generic-classes-and-structs">7.6.2. Generic Classes and Structs</a></li>
+      <li><a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-06-parameters-of-variable-type-generics#_7-6-3-the-user-pointer-case">7.6.3. The User Pointer Case</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="07-00-binding-a-c-function-s-parameter-and-return-types/07-07-pointers">7.7. Pointers</a>
+  </li>
+</ul>

--- a/docs/developer-guides/bindings/writing-a-vapi-manually/08-00-binding-a-c-struct-s-fields.md
+++ b/docs/developer-guides/bindings/writing-a-vapi-manually/08-00-binding-a-c-struct-s-fields.md
@@ -10,8 +10,10 @@ Often times, the details of the structure are in the
 header, but not intended for public consumption; avoid binding variables
 that should not be accessed. Consult the documentation.
 
-#### [8.1. Structs](08-00-binding-a-c-struct-s-fields/08-01-structs)
-#### [8.2. Pointers to Structs](08-00-binding-a-c-struct-s-fields/08-02-pointers-to-structs)
-#### [8.3. Arrays](08-00-binding-a-c-struct-s-fields/08-03-arrays)
-#### [8.4. Function Pointers](08-00-binding-a-c-struct-s-fields/08-04-function-pointers)
-#### [8.5. Unions](08-00-binding-a-c-struct-s-fields/08-05-unions)
+<ul class="section-toc">
+<li><a href="08-00-binding-a-c-struct-s-fields/08-01-structs">8.1. Structs</a></li>
+<li><a href="08-00-binding-a-c-struct-s-fields/08-02-pointers-to-structs">8.2. Pointers to Structs</a></li>
+<li><a href="08-00-binding-a-c-struct-s-fields/08-03-arrays">8.3. Arrays</a></li>
+<li><a href="08-00-binding-a-c-struct-s-fields/08-04-function-pointers">8.4. Function Pointers</a></li>
+<li><a href="08-00-binding-a-c-struct-s-fields/08-05-unions">8.5. Unions</a></li>
+</ul>

--- a/docs/developer-guides/bindings/writing-a-vapi-manually/10-00-awkward-situations.md
+++ b/docs/developer-guides/bindings/writing-a-vapi-manually/10-00-awkward-situations.md
@@ -3,8 +3,10 @@
 There are a number of awkward situations that come up frequently enough
 to deserve answers.
 
-#### [10.1. Array Lengths](10-00-awkward-situations/10-01-array-lengths)
-#### [10.2. Dependently Typed Ownership](10-00-awkward-situations/10-02-dependently-typed-ownership)
-#### [10.3. Member Length](10-00-awkward-situations/10-03-member-length)
-#### [10.4. Owned Array of Unowned Objects](10-00-awkward-situations/10-04-owned-array-of-unowned-objects)
-#### [10.5. Shared Context Delegates](10-00-awkward-situations/10-05-shared-context-delgates)
+<ul class="section-toc">
+<li><a href="10-00-awkward-situations/10-01-array-lengths">10.1. Array Lengths</a></li>
+<li><a href="10-00-awkward-situations/10-02-dependently-typed-ownership">10.2. Dependently Typed Ownership</a></li>
+<li><a href="10-00-awkward-situations/10-03-member-length">10.3. Member Length</a></li>
+<li><a href="10-00-awkward-situations/10-04-owned-array-of-unowned-objects">10.4. Owned Array of Unowned Objects</a></li>
+<li><a href="10-00-awkward-situations/10-05-shared-context-delgates">10.5. Shared Context Delegates</a></li>
+</ul>

--- a/docs/developer-guides/design-patterns.md
+++ b/docs/developer-guides/design-patterns.md
@@ -48,7 +48,9 @@ Wikipedia describes them as
 - [Structural](design-patterns/02-00-structural-design-patterns)
 - [Behavioral](design-patterns/03-00-behavioral-design-patterns)
 
-#### 1. [Creational Design Patterns](design-patterns/01-00-creational-design-patterns)
-#### 2. [Structural Design Patterns](design-patterns/02-00-structural-design-patterns)
-#### 3. [Behavioral Design Patterns](design-patterns/03-00-behavioral-design-patterns)
-#### 4. [🚦 Wrap Up Folks](design-patterns/04-00-wrap-up)
+<ul class="section-toc">
+<li><span class="section-toc-num">1.</span> <a href="design-patterns/01-00-creational-design-patterns">Creational Design Patterns</a></li>
+<li><span class="section-toc-num">2.</span> <a href="design-patterns/02-00-structural-design-patterns">Structural Design Patterns</a></li>
+<li><span class="section-toc-num">3.</span> <a href="design-patterns/03-00-behavioral-design-patterns">Behavioral Design Patterns</a></li>
+<li><span class="section-toc-num">4.</span> <a href="design-patterns/04-00-wrap-up">🚦 Wrap Up Folks</a></li>
+</ul>

--- a/docs/developer-guides/documentation.md
+++ b/docs/developer-guides/documentation.md
@@ -1,4 +1,6 @@
 # Documentation
 
-#### [Vala for C# Programmers](documentation/vala-for-csharp-programmers)
-#### [Valadoc Guide](documentation/valadoc-guide)
+<ul class="section-toc">
+<li><a href="documentation/vala-for-csharp-programmers">Vala for C# Programmers</a></li>
+<li><a href="documentation/valadoc-guide">Valadoc Guide</a></li>
+</ul>

--- a/docs/developer-guides/documentation/vala-for-csharp-programmers.md
+++ b/docs/developer-guides/documentation/vala-for-csharp-programmers.md
@@ -4,41 +4,43 @@ These pages describe the syntax differences, not the similarities
 between Vala and C#. It is intended to be a quick introduction to Vala
 for programmers who already know C#.
 
-#### [Source Files](vala-for-csharp-programmers/01-sources-files)
-#### [Compilation](vala-for-csharp-programmers/02-compilation)
-#### [Naming Conventions](vala-for-csharp-programmers/03-naming-conventions)
-#### [Main Entry Point](vala-for-csharp-programmers/04-main-entry-point)
-#### [System Namespace](vala-for-csharp-programmers/05-system-namespace)
-#### [Value Types](vala-for-csharp-programmers/06-value-types)
-#### [Verbatim String Literals](vala-for-csharp-programmers/07-verbatim-string-literals)
-#### [Documentation Comments](vala-for-csharp-programmers/08-documentation-comments)
-#### [Object Base Class](vala-for-csharp-programmers/09-object-base-class)
-#### [Method Overloading](vala-for-csharp-programmers/10-method-overloading)   
-#### [Multiple Constructors](vala-for-csharp-programmers/11-multiple-constructors)
-#### [Constructor Chaining](vala-for-csharp-programmers/12-constructor-chaining)
-#### [Delegates / Lambdas](vala-for-csharp-programmers/13-delegates-lambdas)
-#### [Events](vala-for-csharp-programmers/14-events)
-#### [Interfaces](vala-for-csharp-programmers/15-interfaces)
-#### [Enums](vala-for-csharp-programmers/16-enums)
-#### [Struct Initialization](vala-for-csharp-programmers/17-struct-initialization)
-#### [Multi-dimensional Arrays](vala-for-csharp-programmers/18-multi-dimensional-arrays)
-#### [Nullable Types](vala-for-csharp-programmers/19-nullable-types)
-#### [Code Attributes](vala-for-csharp-programmers/20-code-attributes)
-#### [Properties](vala-for-csharp-programmers/21-properties)
-#### [Exceptions](vala-for-csharp-programmers/22-exceptions)
-#### [Argument Checking](vala-for-csharp-programmers/23-argument-checking)
-#### [Unsafe Code and Pointers](vala-for-csharp-programmers/24-unsafe-code-and-pointers)
-#### [Conditional Compilation Directives](vala-for-csharp-programmers/25-conditional-compilation-directives)
-#### [Resource Disposing](vala-for-csharp-programmers/26-resource-disposing)
-#### [Memory Management](vala-for-csharp-programmers/27-memory-management)
-#### [Asynchronous Calls](vala-for-csharp-programmers/28-asynchronous-calls)
-#### [Static Constructors](vala-for-csharp-programmers/29-static-constructors)
-#### [External Methods](vala-for-csharp-programmers/30-external-methods)
-#### [Reflection](vala-for-csharp-programmers/31-reflection)
-#### [Not Available](vala-for-csharp-programmers/32-not-available)
-#### [Collections](vala-for-csharp-programmers/33-collections)
-#### [Indexers](vala-for-csharp-programmers/34-indexers)
-#### [IO, Network Sockets](vala-for-csharp-programmers/35-io-network-sockets)
-#### [Console Input / Output](vala-for-csharp-programmers/36-console-input-output)
-#### [GTK+ Demo App](vala-for-csharp-programmers/37-gtk-demo-app)
-#### [Bindings](vala-for-csharp-programmers/38-bindings)
+<ul class="section-toc">
+<li><a href="vala-for-csharp-programmers/01-sources-files">Source Files</a></li>
+<li><a href="vala-for-csharp-programmers/02-compilation">Compilation</a></li>
+<li><a href="vala-for-csharp-programmers/03-naming-conventions">Naming Conventions</a></li>
+<li><a href="vala-for-csharp-programmers/04-main-entry-point">Main Entry Point</a></li>
+<li><a href="vala-for-csharp-programmers/05-system-namespace">System Namespace</a></li>
+<li><a href="vala-for-csharp-programmers/06-value-types">Value Types</a></li>
+<li><a href="vala-for-csharp-programmers/07-verbatim-string-literals">Verbatim String Literals</a></li>
+<li><a href="vala-for-csharp-programmers/08-documentation-comments">Documentation Comments</a></li>
+<li><a href="vala-for-csharp-programmers/09-object-base-class">Object Base Class</a></li>
+<li><a href="vala-for-csharp-programmers/10-method-overloading">Method Overloading</a></li>
+<li><a href="vala-for-csharp-programmers/11-multiple-constructors">Multiple Constructors</a></li>
+<li><a href="vala-for-csharp-programmers/12-constructor-chaining">Constructor Chaining</a></li>
+<li><a href="vala-for-csharp-programmers/13-delegates-lambdas">Delegates / Lambdas</a></li>
+<li><a href="vala-for-csharp-programmers/14-events">Events</a></li>
+<li><a href="vala-for-csharp-programmers/15-interfaces">Interfaces</a></li>
+<li><a href="vala-for-csharp-programmers/16-enums">Enums</a></li>
+<li><a href="vala-for-csharp-programmers/17-struct-initialization">Struct Initialization</a></li>
+<li><a href="vala-for-csharp-programmers/18-multi-dimensional-arrays">Multi-dimensional Arrays</a></li>
+<li><a href="vala-for-csharp-programmers/19-nullable-types">Nullable Types</a></li>
+<li><a href="vala-for-csharp-programmers/20-code-attributes">Code Attributes</a></li>
+<li><a href="vala-for-csharp-programmers/21-properties">Properties</a></li>
+<li><a href="vala-for-csharp-programmers/22-exceptions">Exceptions</a></li>
+<li><a href="vala-for-csharp-programmers/23-argument-checking">Argument Checking</a></li>
+<li><a href="vala-for-csharp-programmers/24-unsafe-code-and-pointers">Unsafe Code and Pointers</a></li>
+<li><a href="vala-for-csharp-programmers/25-conditional-compilation-directives">Conditional Compilation Directives</a></li>
+<li><a href="vala-for-csharp-programmers/26-resource-disposing">Resource Disposing</a></li>
+<li><a href="vala-for-csharp-programmers/27-memory-management">Memory Management</a></li>
+<li><a href="vala-for-csharp-programmers/28-asynchronous-calls">Asynchronous Calls</a></li>
+<li><a href="vala-for-csharp-programmers/29-static-constructors">Static Constructors</a></li>
+<li><a href="vala-for-csharp-programmers/30-external-methods">External Methods</a></li>
+<li><a href="vala-for-csharp-programmers/31-reflection">Reflection</a></li>
+<li><a href="vala-for-csharp-programmers/32-not-available">Not Available</a></li>
+<li><a href="vala-for-csharp-programmers/33-collections">Collections</a></li>
+<li><a href="vala-for-csharp-programmers/34-indexers">Indexers</a></li>
+<li><a href="vala-for-csharp-programmers/35-io-network-sockets">IO, Network Sockets</a></li>
+<li><a href="vala-for-csharp-programmers/36-console-input-output">Console Input / Output</a></li>
+<li><a href="vala-for-csharp-programmers/37-gtk-demo-app">GTK+ Demo App</a></li>
+<li><a href="vala-for-csharp-programmers/38-bindings">Bindings</a></li>
+</ul>

--- a/docs/developer-guides/documentation/valadoc-guide.md
+++ b/docs/developer-guides/documentation/valadoc-guide.md
@@ -13,6 +13,8 @@ file or a GIR file.
 If the library is written in Vala then valadoc can generate the
 documentation from the library's Vala source files.
 
-#### [1. Quick Start](valadoc-guide/01-00-quick-start)
-#### [2. Command Line Tool](valadoc-guide/02-00-command-line-tool)
-#### [3. Documentation Comment Markup](valadoc-guide/03-00-documentation-comment-markup)
+<ul class="section-toc">
+<li><a href="valadoc-guide/01-00-quick-start">1. Quick Start</a></li>
+<li><a href="valadoc-guide/02-00-command-line-tool">2. Command Line Tool</a></li>
+<li><a href="valadoc-guide/03-00-documentation-comment-markup">3. Documentation Comment Markup</a></li>
+</ul>

--- a/docs/developer-guides/documentation/valadoc-guide/03-00-documentation-comment-markup.md
+++ b/docs/developer-guides/documentation/valadoc-guide/03-00-documentation-comment-markup.md
@@ -21,7 +21,9 @@ in the documentation.
 In this chapter, we'll explain how to fill each section of a
 documentation comment.
 
-#### [3.1.1. Brief Description](03-00-documentation-comment-markup/03-01-brief-description)
-#### [3.1.2. Formatting](03-00-documentation-comment-markup/03-02-formatting)
-#### [3.1.3. Taglets](03-00-documentation-comment-markup/03-03-taglets)
-#### [3.1.4. Contributing to Valadoc](03-00-documentation-comment-markup/03-04-contributing-to-valadoc)
+<ul class="section-toc">
+<li><a href="03-00-documentation-comment-markup/03-01-brief-description">3.1.1. Brief Description</a></li>
+<li><a href="03-00-documentation-comment-markup/03-02-formatting">3.1.2. Formatting</a></li>
+<li><a href="03-00-documentation-comment-markup/03-03-taglets">3.1.3. Taglets</a></li>
+<li><a href="03-00-documentation-comment-markup/03-04-contributing-to-valadoc">3.1.4. Contributing to Valadoc</a></li>
+</ul>

--- a/docs/developer-guides/index.md
+++ b/docs/developer-guides/index.md
@@ -1,23 +1,40 @@
 # Developer Guides
 
-#### [Bindings](bindings)
-- [Generating a VAPI with GObject Introspection](bindings/generating-a-vapi-with-gobject-introspection)
-- [Why Distribute Bindings Upstream](bindings/upstream-guide)
-- [Writing a VAPI Manually](bindings/writing-a-vapi-manually)
-
-#### [Design Patterns](design-patterns)
-- [🚀 Introduction](design-patterns#🚀-introduction)
-- [⚠️ Be Careful](design-patterns#⚠️-be-careful)
-- [Types of Design Patterns](design-patterns#types-of-design-patterns)
-
-#### [Memory Management](memory-management)
-
-#### [Documentation](documentation)
-- [Vala for C# Programmers](documentation/vala-for-csharp-programmers)
-- [Valadoc Guide](documentation/valadoc-guide)
-
-#### [Plugins](plugins)
-- [Type Modules](plugins/01-type-modules)
-- [Libpeas](plugins/02-libpeas)
-
-#### [Syntax Guide](syntax-guide)
+<ul class="section-toc">
+  <li>
+    <a href="bindings">Bindings</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="bindings/generating-a-vapi-with-gobject-introspection">Generating a VAPI with GObject Introspection</a></li>
+      <li><a href="bindings/upstream-guide">Why Distribute Bindings Upstream</a></li>
+      <li><a href="bindings/writing-a-vapi-manually">Writing a VAPI Manually</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="design-patterns">Design Patterns</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="design-patterns#🚀-introduction">🚀 Introduction</a></li>
+      <li><a href="design-patterns#⚠️-be-careful">⚠️ Be Careful</a></li>
+      <li><a href="design-patterns#types-of-design-patterns">Types of Design Patterns</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="memory-management">Memory Management</a>
+  </li>
+  <li>
+    <a href="documentation">Documentation</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="documentation/vala-for-csharp-programmers">Vala for C# Programmers</a></li>
+      <li><a href="documentation/valadoc-guide">Valadoc Guide</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="plugins">Plugins</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="plugins/01-type-modules">Type Modules</a></li>
+      <li><a href="plugins/02-libpeas">Libpeas</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="syntax-guide">Syntax Guide</a>
+  </li>
+</ul>

--- a/docs/developer-guides/plugins.md
+++ b/docs/developer-guides/plugins.md
@@ -1,4 +1,6 @@
 # Plugins
 
-#### [Type Modules](plugins/01-type-modules)
-#### [Libpeas](plugins/02-libpeas)
+<ul class="section-toc">
+<li><a href="plugins/01-type-modules">Type Modules</a></li>
+<li><a href="plugins/02-libpeas">Libpeas</a></li>
+</ul>

--- a/docs/sample-code/gee-samples.md
+++ b/docs/sample-code/gee-samples.md
@@ -6,8 +6,10 @@ distribution. More information about libgee is available from
 
 [Gee API Documentation](https://valadoc.org/gee-0.8/index.htm)
 
-#### [List Sample](gee-samples/01-list-sample)
-#### [Set Sample](gee-samples/02-set-sample)
-#### [Map Example](gee-samples/03-map-sample)
-#### [Syntactic Sugar](gee-samples/04-syntactic-sugar)
-#### [Customizing the equality function](gee-samples/05-custom-equality)
+<ul class="section-toc">
+<li><a href="gee-samples/01-list-sample">List Sample</a></li>
+<li><a href="gee-samples/02-set-sample">Set Sample</a></li>
+<li><a href="gee-samples/03-map-sample">Map Example</a></li>
+<li><a href="gee-samples/04-syntactic-sugar">Syntactic Sugar</a></li>
+<li><a href="gee-samples/05-custom-equality">Customizing the equality function</a></li>
+</ul>

--- a/docs/sample-code/gtk4-samples.md
+++ b/docs/sample-code/gtk4-samples.md
@@ -24,12 +24,14 @@ The repository includes the sample code featured on this website.
 
 ## Samples
 
-#### [Minimal App](gtk4-samples/minimal-app)
-#### [Basic App](gtk4-samples/basic-app)
-#### [Synchronising Widgets](gtk4-samples/synchronising-widgets)
-#### [Text File Viewer](gtk4-samples/text-file-viewer)
-#### [ListView](gtk4-samples/list-view) 
-#### [ListView with CheckButtons](gtk4-samples/list-view-check-buttons)
-#### [ColumnView](gtk4-samples/column-view)
-#### [Clipboard](gtk4-samples/clipboard)
-#### [Entry Completion with Two Cells](gtk4-samples/entry-completion-two-cells)
+<ul class="section-toc">
+<li><a href="gtk4-samples/minimal-app">Minimal App</a></li>
+<li><a href="gtk4-samples/basic-app">Basic App</a></li>
+<li><a href="gtk4-samples/synchronising-widgets">Synchronising Widgets</a></li>
+<li><a href="gtk4-samples/text-file-viewer">Text File Viewer</a></li>
+<li><a href="gtk4-samples/list-view">ListView</a></li>
+<li><a href="gtk4-samples/list-view-check-buttons">ListView with CheckButtons</a></li>
+<li><a href="gtk4-samples/column-view">ColumnView</a></li>
+<li><a href="gtk4-samples/clipboard">Clipboard</a></li>
+<li><a href="gtk4-samples/entry-completion-two-cells">Entry Completion with Two Cells</a></li>
+</ul>

--- a/docs/sample-code/index.md
+++ b/docs/sample-code/index.md
@@ -2,11 +2,15 @@
 
 ## Language features and introductory samples
 
-#### [Language Features and Introductory Samples](language-features-and-introductory-samples)
+<ul class="section-toc">
+<li><a href="language-features-and-introductory-samples">Language Features and Introductory Samples</a></li>
+</ul>
 
 ## Other samples
 
-#### [Threading Samples](threading-samples)
-#### [Async Method Samples](async-samples)
-#### [Vala Collections: libgee](gee-samples)
-#### [GTK4 Samples](gtk4-samples)
+<ul class="section-toc">
+<li><a href="threading-samples">Threading Samples</a></li>
+<li><a href="async-samples">Async Method Samples</a></li>
+<li><a href="gee-samples">Vala Collections: libgee</a></li>
+<li><a href="gtk4-samples">GTK4 Samples</a></li>
+</ul>

--- a/docs/sample-code/language-features-and-introductory-samples.md
+++ b/docs/sample-code/language-features-and-introductory-samples.md
@@ -7,10 +7,12 @@ This section is the maintained home for those introductory samples.
 
 ## Samples
 
-#### [Basic Samples](language-features-and-introductory-samples/basic-samples)
-#### [Intermediate Samples](language-features-and-introductory-samples/intermediate-samples)
-#### [String Sample](string-sample)
-#### [Character Sample](language-features-and-introductory-samples/character-sample)
-#### [Signals and Callbacks](signals-and-callbacks)
-#### [Properties Sample](language-features-and-introductory-samples/properties-sample)
-#### [Conditional Compilation Sample](language-features-and-introductory-samples/conditional-compilation-sample)
+<ul class="section-toc">
+<li><a href="language-features-and-introductory-samples/basic-samples">Basic Samples</a></li>
+<li><a href="language-features-and-introductory-samples/intermediate-samples">Intermediate Samples</a></li>
+<li><a href="string-sample">String Sample</a></li>
+<li><a href="language-features-and-introductory-samples/character-sample">Character Sample</a></li>
+<li><a href="signals-and-callbacks">Signals and Callbacks</a></li>
+<li><a href="language-features-and-introductory-samples/properties-sample">Properties Sample</a></li>
+<li><a href="language-features-and-introductory-samples/conditional-compilation-sample">Conditional Compilation Sample</a></li>
+</ul>

--- a/docs/tooling/index.md
+++ b/docs/tooling/index.md
@@ -1,7 +1,9 @@
 # Tooling
 
-#### [Build Systems](build-systems)
-#### [Code Editors and IDEs](code-editors-and-ides)
-#### [Language Server Protocol Support](language-server-protocol-support)
-#### [Other Tools](other-tools)
-#### [Syntax Support](syntax-support)
+<ul class="section-toc">
+<li><a href="build-systems">Build Systems</a></li>
+<li><a href="code-editors-and-ides">Code Editors and IDEs</a></li>
+<li><a href="language-server-protocol-support">Language Server Protocol Support</a></li>
+<li><a href="other-tools">Other Tools</a></li>
+<li><a href="syntax-support">Syntax Support</a></li>
+</ul>

--- a/docs/tutorials/gui-programming.md
+++ b/docs/tutorials/gui-programming.md
@@ -1,4 +1,6 @@
 # GUI Programming
 
-#### [GNOME Developer Documentation - Tutorials](https://developer.gnome.org/documentation/tutorials.html)
-#### [elementary OS - Writing Apps](https://docs.elementary.io/develop/writing-apps/the-basic-setup)
+<ul class="section-toc">
+<li><a href="https://developer.gnome.org/documentation/tutorials.html">GNOME Developer Documentation - Tutorials</a></li>
+<li><a href="https://docs.elementary.io/develop/writing-apps/the-basic-setup">elementary OS - Writing Apps</a></li>
+</ul>

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,7 +1,17 @@
 # Tutorials
-#### [Programming Language](programming-language)
-- [Main Tutorial](programming-language/main)
 
-#### [GUI Programming](gui-programming)
-- [GNOME Developer Documentation - Tutorials](https://developer.gnome.org/documentation/tutorials.html)
-- [elementary OS - Writing Apps](https://docs.elementary.io/develop/writing-apps/the-basic-setup)
+<ul class="section-toc">
+  <li>
+    <a href="programming-language">Programming Language</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="programming-language/main">Main Tutorial</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="gui-programming">GUI Programming</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="https://developer.gnome.org/documentation/tutorials.html">GNOME Developer Documentation - Tutorials</a></li>
+      <li><a href="https://docs.elementary.io/develop/writing-apps/the-basic-setup">elementary OS - Writing Apps</a></li>
+    </ul>
+  </li>
+</ul>

--- a/docs/tutorials/programming-language.md
+++ b/docs/tutorials/programming-language.md
@@ -1,3 +1,5 @@
 # Programming Language
 
-#### [Main Tutorial](programming-language/main)
+<ul class="section-toc">
+<li><a href="programming-language/main">Main Tutorial</a></li>
+</ul>

--- a/docs/tutorials/programming-language/main.md
+++ b/docs/tutorials/programming-language/main.md
@@ -74,11 +74,29 @@ that doesn't mean that I encourage you do to this.
 At some point I will add in references to the Vala documentation, but
 that isn't really possible yet.
 
-#### [1. First Program](main/01-00-first-program)
-#### [2. Basics](main/02-00-basics)
-#### [3. Object Oriented Programming](main/03-00-object-oriented-programming)
-#### [4. Advanced Features](main/04-00-advanced-features)
-#### [5. Experimental Features](main/05-00-experimental-features)
-#### [6. Libraries](main/06-00-libraries)
-#### [7. Tools](main/07-00-tools)
-#### [8. Techniques](main/08-00-techniques)
+<ul class="section-toc">
+  <li>
+    <a href="main/01-00-first-program">1. First Program</a>
+  </li>
+  <li>
+    <a href="main/02-00-basics">2. Basics</a>
+  </li>
+  <li>
+    <a href="main/03-00-object-oriented-programming">3. Object Oriented Programming</a>
+  </li>
+  <li>
+    <a href="main/04-00-advanced-features">4. Advanced Features</a>
+  </li>
+  <li>
+    <a href="main/05-00-experimental-features">5. Experimental Features</a>
+  </li>
+  <li>
+    <a href="main/06-00-libraries">6. Libraries</a>
+  </li>
+  <li>
+    <a href="main/07-00-tools">7. Tools</a>
+  </li>
+  <li>
+    <a href="main/08-00-techniques">8. Techniques</a>
+  </li>
+</ul>

--- a/docs/tutorials/programming-language/main/02-00-basics.md
+++ b/docs/tutorials/programming-language/main/02-00-basics.md
@@ -1,29 +1,47 @@
 # 2. Basics
 
-#### [2.1. Source Files and Compilation](02-00-basics/02-01-source-files-and-compilation)
-#### [2.2. Syntax Overview](02-00-basics/02-02-syntax-overview)
-#### [2.3. Comments](02-00-basics/02-03-comments)
-#### [2.4. Data Types](02-00-basics/02-04-data-types)
-
-- [2.4.1. Value Types](02-00-basics/02-04-data-types#_2-4-1-value-types)
-- [2.4.2. Strings](02-00-basics/02-04-data-types#_2-4-2-strings)
-- [2.4.3. Arrays](02-00-basics/02-04-data-types#_2-4-3-arrays)
-- [2.4.4. Reference Types](02-00-basics/02-04-data-types#_2-4-4-reference-types)
-- [2.4.5. Static Type Casting](02-00-basics/02-04-data-types#_2-4-5-static-type-casting)
-- [2.4.6. Type Inference](02-00-basics/02-04-data-types#_2-4-6-type-inference)
-- [2.4.7. Defining new Type from other](02-00-basics/02-04-data-types#_2-4-7-defining-new-type-from-other)
-- [2.4.8. Numeric Type Suffixes](02-00-basics/02-04-data-types#_2-4-8-numeric-type-suffixes)
-
-#### [2.5. Operators](02-00-basics/02-05-operators)
-#### [2.6. Control Structures](02-00-basics/02-06-control-structures)
-#### [2.7. Language Elements](02-00-basics/02-07-language-elements)
-- [2.7.1. Methods](02-00-basics/02-07-language-elements#_2-7-1-methods)
-- [2.7.2. Delegates](02-00-basics/02-07-language-elements#_2-7-2-delegates)
-- [2.7.3. Anonymous Methods / Closures](02-00-basics/02-07-language-elements#_2-7-3-anonymous-methods-closures)
-- [2.7.4. Namespaces](02-00-basics/02-07-language-elements#_2-7-4-namespaces)
-- [2.7.5. Structs](02-00-basics/02-07-language-elements#_2-7-5-structs)
-- [2.7.6. Classes](02-00-basics/02-07-language-elements#_2-7-6-classes)
-- [2.7.7. Interfaces](02-00-basics/02-07-language-elements#_2-7-7-interfaces)
-
-
-#### [2.8. Code Attributes](02-00-basics/02-08-code-attributes)
+<ul class="section-toc">
+  <li>
+    <a href="02-00-basics/02-01-source-files-and-compilation">2.1. Source Files and Compilation</a>
+  </li>
+  <li>
+    <a href="02-00-basics/02-02-syntax-overview">2.2. Syntax Overview</a>
+  </li>
+  <li>
+    <a href="02-00-basics/02-03-comments">2.3. Comments</a>
+  </li>
+  <li>
+    <a href="02-00-basics/02-04-data-types">2.4. Data Types</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="02-00-basics/02-04-data-types#_2-4-1-value-types">2.4.1. Value Types</a></li>
+      <li><a href="02-00-basics/02-04-data-types#_2-4-2-strings">2.4.2. Strings</a></li>
+      <li><a href="02-00-basics/02-04-data-types#_2-4-3-arrays">2.4.3. Arrays</a></li>
+      <li><a href="02-00-basics/02-04-data-types#_2-4-4-reference-types">2.4.4. Reference Types</a></li>
+      <li><a href="02-00-basics/02-04-data-types#_2-4-5-static-type-casting">2.4.5. Static Type Casting</a></li>
+      <li><a href="02-00-basics/02-04-data-types#_2-4-6-type-inference">2.4.6. Type Inference</a></li>
+      <li><a href="02-00-basics/02-04-data-types#_2-4-7-defining-new-type-from-other">2.4.7. Defining new Type from other</a></li>
+      <li><a href="02-00-basics/02-04-data-types#_2-4-8-numeric-type-suffixes">2.4.8. Numeric Type Suffixes</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="02-00-basics/02-05-operators">2.5. Operators</a>
+  </li>
+  <li>
+    <a href="02-00-basics/02-06-control-structures">2.6. Control Structures</a>
+  </li>
+  <li>
+    <a href="02-00-basics/02-07-language-elements">2.7. Language Elements</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="02-00-basics/02-07-language-elements#_2-7-1-methods">2.7.1. Methods</a></li>
+      <li><a href="02-00-basics/02-07-language-elements#_2-7-2-delegates">2.7.2. Delegates</a></li>
+      <li><a href="02-00-basics/02-07-language-elements#_2-7-3-anonymous-methods-closures">2.7.3. Anonymous Methods / Closures</a></li>
+      <li><a href="02-00-basics/02-07-language-elements#_2-7-4-namespaces">2.7.4. Namespaces</a></li>
+      <li><a href="02-00-basics/02-07-language-elements#_2-7-5-structs">2.7.5. Structs</a></li>
+      <li><a href="02-00-basics/02-07-language-elements#_2-7-6-classes">2.7.6. Classes</a></li>
+      <li><a href="02-00-basics/02-07-language-elements#_2-7-7-interfaces">2.7.7. Interfaces</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="02-00-basics/02-08-code-attributes">2.8. Code Attributes</a>
+  </li>
+</ul>

--- a/docs/tutorials/programming-language/main/03-00-object-oriented-programming.md
+++ b/docs/tutorials/programming-language/main/03-00-object-oriented-programming.md
@@ -1,23 +1,55 @@
 # Object Oriented Programming
 
-#### [3.1. Basics](03-00-object-oriented-programming/03-01-basics)
-#### [3.2. Construction](03-00-object-oriented-programming/03-02-construction)
-#### [3.3. Destruction](03-00-object-oriented-programming/03-03-destruction)
-#### [3.4. Signals](03-00-object-oriented-programming/03-04-signals)
-#### [3.5. Properties](03-00-object-oriented-programming/03-05-properties)
-#### [3.6. Inheritance](03-00-object-oriented-programming/03-06-inheritance)
-#### [3.7. Abstract Classes](03-00-object-oriented-programming/03-07-abstract-classes)
-- [3.7.1. Virtual Methods](03-00-object-oriented-programming/03-07-abstract-classes#_3-7-1-virtual-methods)
-
-#### [3.8. Interfaces](03-00-object-oriented-programming/03-08-interfaces)
-- [3.8.1. Defining Prerequisites](03-00-object-oriented-programming/03-08-interfaces#_3-8-1-defining-prerequisites)
-- [3.8.2. Defining default implementation in methods](03-00-object-oriented-programming/03-08-interfaces#_3-8-2-defining-default-implementation-in-methods)
-- [3.8.3. Properties](03-00-object-oriented-programming/03-08-interfaces#_3-8-3-properties)
-- [3.8.4. Mixins and Multiple Inheritance](03-00-object-oriented-programming/03-08-interfaces#_3-8-4-mixins-and-multiple-inheritance)
-
-#### [3.9. Polymorphism](03-00-object-oriented-programming/03-09-polymorphism)
-#### [3.10. Method Hiding](03-00-object-oriented-programming/03-10-method-hiding)
-#### [3.11. Run-Time Type Information](03-00-object-oriented-programming/03-11-run-time-type-information)
-#### [3.12. Dynamic Type Casting](03-00-object-oriented-programming/03-12-dynamic-type-casting)
-#### [3.13. Generics](03-00-object-oriented-programming/03-13-generics)
-#### [3.14. GObject-Style Construction](03-00-object-oriented-programming/03-14-gobject-style-construction)
+<ul class="section-toc">
+  <li>
+    <a href="03-00-object-oriented-programming/03-01-basics">3.1. Basics</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-02-construction">3.2. Construction</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-03-destruction">3.3. Destruction</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-04-signals">3.4. Signals</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-05-properties">3.5. Properties</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-06-inheritance">3.6. Inheritance</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-07-abstract-classes">3.7. Abstract Classes</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="03-00-object-oriented-programming/03-07-abstract-classes#_3-7-1-virtual-methods">3.7.1. Virtual Methods</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-08-interfaces">3.8. Interfaces</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="03-00-object-oriented-programming/03-08-interfaces#_3-8-1-defining-prerequisites">3.8.1. Defining Prerequisites</a></li>
+      <li><a href="03-00-object-oriented-programming/03-08-interfaces#_3-8-2-defining-default-implementation-in-methods">3.8.2. Defining default implementation in methods</a></li>
+      <li><a href="03-00-object-oriented-programming/03-08-interfaces#_3-8-3-properties">3.8.3. Properties</a></li>
+      <li><a href="03-00-object-oriented-programming/03-08-interfaces#_3-8-4-mixins-and-multiple-inheritance">3.8.4. Mixins and Multiple Inheritance</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-09-polymorphism">3.9. Polymorphism</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-10-method-hiding">3.10. Method Hiding</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-11-run-time-type-information">3.11. Run-Time Type Information</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-12-dynamic-type-casting">3.12. Dynamic Type Casting</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-13-generics">3.13. Generics</a>
+  </li>
+  <li>
+    <a href="03-00-object-oriented-programming/03-14-gobject-style-construction">3.14. GObject-Style Construction</a>
+  </li>
+</ul>

--- a/docs/tutorials/programming-language/main/04-00-advanced-features.md
+++ b/docs/tutorials/programming-language/main/04-00-advanced-features.md
@@ -1,32 +1,68 @@
 # 4. Advanced Features
 
-#### [4.1. Assertions and Contract Programming](04-00-advanced-features/04-01-assertions-and-contract-programming)
-#### [4.2. Error Handling](04-00-advanced-features/04-02-error-handling)
-#### [4.3. Parameter Directions](04-00-advanced-features/04-03-parameter-directions)
-#### [4.4. Collections](04-00-advanced-features/04-04-collections)
-- [4.4.1. ArrayList\<G\>](04-00-advanced-features/04-04-collections#_4-4-1-arraylist-g)
-- [4.4.2. HashMap\<K,V\>](04-00-advanced-features/04-04-collections#_4-4-2-hashmap-k-v)
-- [4.4.3. HashSet\<G\>](04-00-advanced-features/04-04-collections#_4-4-3-hashset-g)
-- [4.4.4. Read-Only Views](04-00-advanced-features/04-04-collections#_4-4-4-read-only-views)
-
-#### [4.5. Methods with Syntax Support](04-00-advanced-features/04-05-methods-with-syntax-support)
-#### [4.6. Multi-Threading](04-00-advanced-features/04-06-multi-threading)
-- [4.6.1. Threads in Vala](04-00-advanced-features/04-06-multi-threading#_4-6-1-threads-in-vala)
-- [4.6.2. Resource Control](04-00-advanced-features/04-06-multi-threading#_4-6-2-resource-control)
-
-#### [4.7. The Main Loop](04-00-advanced-features/04-07-the-main-loop)
-#### [4.8. Asynchronous Methods](04-00-advanced-features/04-08-asynchronous-methods)
-- [4.8.1. Examples](04-00-advanced-features/04-08-asynchronous-methods#_4-8-1-examples)
-
-#### [4.9. Weak References](04-00-advanced-features/04-09-weak-references)
-#### [4.10. Ownership](04-00-advanced-features/04-10-ownership)
-- [4.10.1. Unowned References](04-00-advanced-features/04-10-ownership#_4-10-1-unowned-references)
-- [4.10.2. Methods ownership](04-00-advanced-features/04-10-ownership#_4-10-2-methods-ownership)
-- [4.10.3. Properties ownership](04-00-advanced-features/04-10-ownership#_4-10-3-properties-ownership)
-- [4.10.4. Ownership Transfer](04-00-advanced-features/04-10-ownership#_4-10-4-ownership-transfer)
-
-#### [4.11. Variable Length Argument Lists](04-00-advanced-features/04-11-variable-length-argument-lists)
-#### [4.12. Pointers](04-00-advanced-features/04-12-pointers)
-#### [4.13. Non-Object Classes](04-00-advanced-features/04-13-non-object-classes)
-#### [4.14. D-Bus Integration](04-00-advanced-features/04-14-d-bus-integration)
-#### [4.15. Profiles](04-00-advanced-features/04-15-profiles)
+<ul class="section-toc">
+  <li>
+    <a href="04-00-advanced-features/04-01-assertions-and-contract-programming">4.1. Assertions and Contract Programming</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-02-error-handling">4.2. Error Handling</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-03-parameter-directions">4.3. Parameter Directions</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-04-collections">4.4. Collections</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="04-00-advanced-features/04-04-collections#_4-4-1-arraylist-g">4.4.1. ArrayList&lt;G&gt;</a></li>
+      <li><a href="04-00-advanced-features/04-04-collections#_4-4-2-hashmap-k-v">4.4.2. HashMap&lt;K,V&gt;</a></li>
+      <li><a href="04-00-advanced-features/04-04-collections#_4-4-3-hashset-g">4.4.3. HashSet&lt;G&gt;</a></li>
+      <li><a href="04-00-advanced-features/04-04-collections#_4-4-4-read-only-views">4.4.4. Read-Only Views</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-05-methods-with-syntax-support">4.5. Methods with Syntax Support</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-06-multi-threading">4.6. Multi-Threading</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="04-00-advanced-features/04-06-multi-threading#_4-6-1-threads-in-vala">4.6.1. Threads in Vala</a></li>
+      <li><a href="04-00-advanced-features/04-06-multi-threading#_4-6-2-resource-control">4.6.2. Resource Control</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-07-the-main-loop">4.7. The Main Loop</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-08-asynchronous-methods">4.8. Asynchronous Methods</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="04-00-advanced-features/04-08-asynchronous-methods#_4-8-1-examples">4.8.1. Examples</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-09-weak-references">4.9. Weak References</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-10-ownership">4.10. Ownership</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="04-00-advanced-features/04-10-ownership#_4-10-1-unowned-references">4.10.1. Unowned References</a></li>
+      <li><a href="04-00-advanced-features/04-10-ownership#_4-10-2-methods-ownership">4.10.2. Methods ownership</a></li>
+      <li><a href="04-00-advanced-features/04-10-ownership#_4-10-3-properties-ownership">4.10.3. Properties ownership</a></li>
+      <li><a href="04-00-advanced-features/04-10-ownership#_4-10-4-ownership-transfer">4.10.4. Ownership Transfer</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-11-variable-length-argument-lists">4.11. Variable Length Argument Lists</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-12-pointers">4.12. Pointers</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-13-non-object-classes">4.13. Non-Object Classes</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-14-d-bus-integration">4.14. D-Bus Integration</a>
+  </li>
+  <li>
+    <a href="04-00-advanced-features/04-15-profiles">4.15. Profiles</a>
+  </li>
+</ul>

--- a/docs/tutorials/programming-language/main/04-00-advanced-features/04-05-methods-with-syntax-support.md
+++ b/docs/tutorials/programming-language/main/04-00-advanced-features/04-05-methods-with-syntax-support.md
@@ -7,19 +7,22 @@ operator. The following table lists these special methods. *T* and *Tn*
 are only type placeholders in this table and meant to be replaced with
 real types.
 
-#### Indexers
+## Indexers
+
 | Method                          | Description                           |
 |---------------------------------|---------------------------------------|
 | `T2 get (T1 index)`             | Index access: `obj[index]`            |
 | `void set (T1 index, T2 item)`  | Index assignment: `obj[index] = item` |
 
-#### Indexers with multiple indices
+## Indexers with multiple indices
+
 | Method                                     | Description                                    |
 |--------------------------------------------|------------------------------------------------|
 | `T3 get (T1 index1, T2 index2)`            | Index access: `obj[index1, index2]`            |
 | `void set (T1 index1, T2 index2, T3 item)` | Index assignment: `obj[index1, index2] = item` |
 
-#### Others
+## Others
+
 | Method                                       | Description                                |
 |----------------------------------------------|--------------------------------------------|
 | `T slice (long start, long end)`             | Slicing: `obj[start:end]`                  |

--- a/docs/tutorials/programming-language/main/05-00-experimental-features.md
+++ b/docs/tutorials/programming-language/main/05-00-experimental-features.md
@@ -3,6 +3,8 @@
 Some features of Vala are experimental. This means they are not fully
 tested and might be subject to changes in future versions.
 
-#### [5.1. Chained Relational Expressions](05-00-experimental-features/05-01-chained-relational-expressions)
-#### [5.2. Regular Expression Literals](05-00-experimental-features/05-02-regular-expression-literals)
-#### [5.3. Strict Non-Null Mode](05-00-experimental-features/05-03-strict-non-null-mode)
+<ul class="section-toc">
+<li><a href="05-00-experimental-features/05-01-chained-relational-expressions">5.1. Chained Relational Expressions</a></li>
+<li><a href="05-00-experimental-features/05-02-regular-expression-literals">5.2. Regular Expression Literals</a></li>
+<li><a href="05-00-experimental-features/05-03-strict-non-null-mode">5.3. Strict Non-Null Mode</a></li>
+</ul>

--- a/docs/tutorials/programming-language/main/06-00-libraries.md
+++ b/docs/tutorials/programming-language/main/06-00-libraries.md
@@ -20,23 +20,42 @@ These files are explained later in this section. It should be noted that
 the library names are the same in the Vala specific files as in the
 *pkg-config* files.
 
-#### [6.1. Using Libraries](06-00-libraries/06-01-using-libraries)
-#### [6.2. Creating a Library](06-00-libraries/06-02-creating-a-library)
-- [6.2.1. Compilation and linking using Command Line](06-00-libraries/06-02-creating-a-library#_6-2-1-compilation-and-linking-using-command-line)
-
-#### [6.3. Binding Libraries with VAPI Files](06-00-libraries/06-03-binding-libraries-with-vapi-files)
-#### [6.4. ABI and API Design Choices](06-00-libraries/06-04-abi-and-api-design-choices)
-- [6.4.1. ABI](06-00-libraries/06-04-abi-and-api-design-choices#_6-4-1-abi)
-- [6.4.2. API Design](06-00-libraries/06-04-abi-and-api-design-choices#_6-4-2-api-design)
-- [6.4.3. Further Reading](06-00-libraries/06-04-abi-and-api-design-choices#_6-4-3-further-reading)
-
-#### [6.5. Binding to Vala Libraries from Other Languages](06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages)
-- [6.5.1. Haskell](06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-1-haskell)
-- [6.5.2. JavaScript](06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-2-javascript)
-- [6.5.3. Lua](06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-3-lua)
-- [6.5.4. Perl](06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-4-perl)
-- [6.5.5. Python](06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-5-python)
-- [6.5.6. Rust](06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-6-rust)
-
-#### [6.6. Using Autotools](06-00-libraries/06-06-using-autotools)
-- [6.6.1. Example](06-00-libraries/06-06-using-autotools#_6-6-1-example)
+<ul class="section-toc">
+  <li>
+    <a href="06-00-libraries/06-01-using-libraries">6.1. Using Libraries</a>
+  </li>
+  <li>
+    <a href="06-00-libraries/06-02-creating-a-library">6.2. Creating a Library</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="06-00-libraries/06-02-creating-a-library#_6-2-1-compilation-and-linking-using-command-line">6.2.1. Compilation and linking using Command Line</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="06-00-libraries/06-03-binding-libraries-with-vapi-files">6.3. Binding Libraries with VAPI Files</a>
+  </li>
+  <li>
+    <a href="06-00-libraries/06-04-abi-and-api-design-choices">6.4. ABI and API Design Choices</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="06-00-libraries/06-04-abi-and-api-design-choices#_6-4-1-abi">6.4.1. ABI</a></li>
+      <li><a href="06-00-libraries/06-04-abi-and-api-design-choices#_6-4-2-api-design">6.4.2. API Design</a></li>
+      <li><a href="06-00-libraries/06-04-abi-and-api-design-choices#_6-4-3-further-reading">6.4.3. Further Reading</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages">6.5. Binding to Vala Libraries from Other Languages</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-1-haskell">6.5.1. Haskell</a></li>
+      <li><a href="06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-2-javascript">6.5.2. JavaScript</a></li>
+      <li><a href="06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-3-lua">6.5.3. Lua</a></li>
+      <li><a href="06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-4-perl">6.5.4. Perl</a></li>
+      <li><a href="06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-5-python">6.5.5. Python</a></li>
+      <li><a href="06-00-libraries/06-05-binding-to-vala-libraries-from-other-languages#_6-5-6-rust">6.5.6. Rust</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="06-00-libraries/06-06-using-autotools">6.6. Using Autotools</a>
+    <ul class="section-toc section-toc-sub">
+      <li><a href="06-00-libraries/06-06-using-autotools#_6-6-1-example">6.6.1. Example</a></li>
+    </ul>
+  </li>
+</ul>

--- a/docs/tutorials/programming-language/main/07-00-tools.md
+++ b/docs/tutorials/programming-language/main/07-00-tools.md
@@ -4,7 +4,9 @@ The Vala distribution includes several programs to help you build and
 work with Vala applications. For more details of each tool, see the man
 pages.
 
-#### [7.1. valac](07-00-tools/07-01-valac)
-#### [7.2. valadoc](07-00-tools/07-02-valadoc)
-#### [7.3. vapigen](07-00-tools/07-03-vapigen)
-#### [7.4. vala-gen-introspect](07-00-tools/07-04-vala-gen-introspect)
+<ul class="section-toc">
+<li><a href="07-00-tools/07-01-valac">7.1. valac</a></li>
+<li><a href="07-00-tools/07-02-valadoc">7.2. valadoc</a></li>
+<li><a href="07-00-tools/07-03-vapigen">7.3. vapigen</a></li>
+<li><a href="07-00-tools/07-04-vala-gen-introspect">7.4. vala-gen-introspect</a></li>
+</ul>

--- a/docs/tutorials/programming-language/main/08-00-techniques.md
+++ b/docs/tutorials/programming-language/main/08-00-techniques.md
@@ -1,5 +1,15 @@
 # 8. Techniques
 
-#### [8.1. Debugging](08-00-techniques/08-01-debugging)
-#### [8.2. Using GLib](08-00-techniques/08-02-using-glib)
-- [8.2.1. File Handling](08-00-techniques/08-02-using-glib#_8-2-1-file-handling)
+<ul class="section-toc">
+  <li>
+    <a href="08-00-techniques/08-01-debugging">8.1. Debugging</a>
+  </li>
+  <li>
+    <a href="08-00-techniques/08-02-using-glib">8.2. Using GLib</a>
+    <ul class="section-toc section-toc-sub">
+      <li>
+        <a href="08-00-techniques/08-02-using-glib#_8-2-1-file-handling">8.2.1. File Handling</a>
+      </li>
+    </ul>
+  </li>
+</ul>


### PR DESCRIPTION
Fixes #130 