### PR TITLE
Fill in some missing data in contributor and compiler guide

### DIFF
--- a/docs/contributor-guide/compiler-guide/06-00-other-tools.md
+++ b/docs/contributor-guide/compiler-guide/06-00-other-tools.md
@@ -1,25 +1,10 @@
 # 6. Other Tools
 
-## 6.1. gen-introspect
+## 6.1. vapigen
 
-::: info TODO
-Add information about the gen-introspect tool
+`vapigen` is a tool to make bindings. It creates VAPI files from a library's metadata and any extra information required.
 
-Feel free to help: [Vala Docs Repository](https://github.com/vala-lang/vala-docs).
-:::
+## 6.2. vala-gen-introspect
 
-## 6.2. vapigen
+`vala-gen-introspect` is a tool for extracting metainformation about GObject based libraries. Nowadays, the preferred method is to use GObject Introspection instead, as `vapigen` can use GIR files directly.
 
-::: info TODO
-Add information about the vapigen tool
-
-Feel free to help: [Vala Docs Repository](https://github.com/vala-lang/vala-docs).
-:::
-
-## 6.3. vala-gen-introspect
-
-::: info TODO
-Add information about the vala-gen-introspect tool
-
-Feel free to help: [Vala Docs Repository](https://github.com/vala-lang/vala-docs).
-:::

--- a/docs/contributor-guide/compiler-guide/08-00-documentation.md
+++ b/docs/contributor-guide/compiler-guide/08-00-documentation.md
@@ -5,9 +5,8 @@ directory: [https://gitlab.gnome.org/GNOME/vala/-/tree/main/doc/manual](https://
 You can rebuild the docs by `cd`'ing into `doc/vala` and typing `make`.
 
 The source code for the compiler guide is in
-[https://github.com/vala-lang/vala-docs/tree/main/source/contributor-guide](https://github.com/vala-lang/vala-docs/tree/main/source/contributor-guide).
-HTML documentation is built by default. This document can be rebuilt by
-running `./build-docs` in the repository's root.
+[https://github.com/vala-lang/vala-docs/tree/main/docs/contributor-guide](https://github.com/vala-lang/vala-docs/tree/main/docs/contributor-guide).
+HTML documentation is built by default. Check out the README file at the root of the git repository for build instructions: https://github.com/vala-lang/vala-docs/
 
 Generated bindings documentation (via valadoc) from the compiler are available here: https://gnome.pages.gitlab.gnome.org/vala/docs/index.html
 

--- a/docs/contributor-guide/compiler-guide/08-00-documentation.md
+++ b/docs/contributor-guide/compiler-guide/08-00-documentation.md
@@ -9,17 +9,9 @@ The source code for the compiler guide is in
 HTML documentation is built by default. This document can be rebuilt by
 running `./build-docs` in the repository's root.
 
-::: info TODO
-Add Generated binding documentation
+Generated bindings documentation (via valadoc) from the compiler are available here: https://gnome.pages.gitlab.gnome.org/vala/docs/index.html
 
-Feel free to help: [Vala Docs Repository](https://github.com/vala-lang/vala-docs).
-:::
-
-::: info TODO
-Add libvala documentation
-
-Feel free to help: [Vala Docs Repository](https://github.com/vala-lang/vala-docs).
-:::
+libvala documentation is here: https://gnome.pages.gitlab.gnome.org/vala/docs/vala/index.htm
 
 [https://github.com/vala-lang/vala-docs](https://github.com/vala-lang/vala-docs) - The documentation repository
 (the source code for this website) is open to anyone who would like to

--- a/docs/contributor-guide/index.md
+++ b/docs/contributor-guide/index.md
@@ -23,7 +23,7 @@ Vala uses [GNOME's GitLab](https://gitlab.gnome.org/GNOME/vala/issues) to track 
 
 Patches should be submitted through Vala's GNOME GitLab instance as a
 [merge request](https://gitlab.gnome.org/GNOME/vala/merge_requests). See
-the [GNOME Wiki's GitLab documentation](https://wiki.gnome.org/GitLab)
+the [GNOME Project Handbook - Change Submission Page](https://handbook.gnome.org/development/change-submission.html/)
 for more details.
 
 If you are not a GNOME developer then you will need to first create a

--- a/docs/contributor-guide/index.md
+++ b/docs/contributor-guide/index.md
@@ -43,11 +43,23 @@ up the changes and show them in the merge request.
 
 ### Committing Patches
 
-::: info TODO
-Add information about how to commit patches to the compiler project.
+#### Commit title conventions
 
-Feel free to help: [Vala Docs Repository](https://github.com/vala-lang/vala-docs).
-:::
+In commits made to the repo, the commit
+titles typically have the following format: `type_or_location_of_change: Summary of change`.
+
+Here's are some examples: 
+- "glib-2.0: allow FileUtils.open_tmp's first argument to be null".
+- "ci: Skip meson dist in flatpak jobs"
+- "vala: Keep depfile empty if no dependencies were written"
+
+If changes have been made to multiple parts of the repo, you can reference multiple locations in a comma-separated list
+like this: "vala, libvaladoc: Fix color support detection in log reporting".
+
+While this commit title format is not mandatory, it does give reviewers context of the changes made
+in your commits at a glance.
+
+Merge requests titles tend to use the same title conventions too.
 
 ## Maintaining Bindings
 

--- a/docs/tutorials/programming-language/main/07-00-tools/07-04-vala-gen-introspect.md
+++ b/docs/tutorials/programming-language/main/07-00-tools/07-04-vala-gen-introspect.md
@@ -2,5 +2,5 @@
 
 `vala-gen-introspect` is a tool for extracting metainformation about
 GObject based libraries. Nowadays, the preferred method is to use
-GObjectIntrospection instead, as vapigen can use GIR files directly. See also
+GObject Introspection instead, as vapigen can use GIR files directly. See also
 [Vala Bindings Tutorial](../../../../developer-guides/bindings/generating-a-vapi-with-gobject-introspection)


### PR DESCRIPTION
- Add info about commit title conventions in Contributor Guide  
- Replace reference to GNOME GitLab page in GNOME Wiki with GNOME Handbook Change Submission Page link  
- Update compiler guide source code info in documentation page of contributor guide  
- Add links generated bindings and libvala documentation in compiler guide documentation page  
- Add info on vapigen and vala-gen-introspect tool in compiler guide