### PR TITLE
fix: typo in sidebar "Lanugage" → "Language"

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1716,7 +1716,7 @@ export default {
                         ],
                     },
                     {
-                        text: "Genie Programming Lanugage",
+                        text: "Genie Programming Language",
                         link: "/genie/",
                         collapsed: true,
                         items: [


### PR DESCRIPTION
Fix typo in the Genie section sidebar label.