### PR TITLE
Fix typo in contributor guide

### DIFF
--- a/docs/guides/contributor-guide.md
+++ b/docs/guides/contributor-guide.md
@@ -36,7 +36,7 @@ Patches will also be accepted as attachments to an issue.
 
 Testing and reviewing merge requests helps reduce the burden on the maintainers and helps speed up development of the project.
 
-For example: If there's a merge request that adds a feature that you like, helping test and review the merge request may speed up the amoount of time it takes to get the feature added into the project.
+For example: If there's a merge request that adds a feature that you like, helping test and review the merge request may speed up the amount of time it takes to get the feature added into the project.
 
 #### Keeping your pending merge requests up-to-date
 


### PR DESCRIPTION
Corrected a typo in the contributor guide regarding the speed of merging features.